### PR TITLE
Add card slot placeholders to right pane

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,18 @@
 <body>
     <div id="orientation-warning">Please rotate your device to landscape.</div>
     <div id="game">
-        <div id="left-pane" class="pane">Left Side</div>
+        <div id="left-pane" class="pane">
+            <div id="card-grid">
+                <div class="card-slot"></div>
+                <div class="card-slot"></div>
+                <div class="card-slot"></div>
+                <div class="card-slot"></div>
+                <div class="card-slot"></div>
+                <div class="card-slot"></div>
+                <div class="card-slot"></div>
+                <div class="card-slot"></div>
+            </div>
+        </div>
         <div id="divider"></div>
         <div id="right-pane" class="pane">Right Side</div>
     </div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
 <body>
     <div id="orientation-warning">Please rotate your device to landscape.</div>
     <div id="game">
-        <div id="left-pane" class="pane">
+        <div id="left-pane" class="pane">Left Side</div>
+        <div id="divider"></div>
+        <div id="right-pane" class="pane">
             <div id="card-grid">
                 <div class="card-slot"></div>
                 <div class="card-slot"></div>
@@ -21,8 +23,6 @@
                 <div class="card-slot"></div>
             </div>
         </div>
-        <div id="divider"></div>
-        <div id="right-pane" class="pane">Right Side</div>
     </div>
     <script src="game.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -21,6 +21,20 @@ html, body {
     justify-content: center;
 }
 
+#card-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 80px);
+    grid-template-rows: repeat(2, 120px);
+    gap: 10px;
+}
+
+.card-slot {
+    width: 80px;
+    height: 120px;
+    border: 2px dashed #ccc;
+    border-radius: 8px;
+}
+
 #divider {
     width: 4px;
     background: #333;


### PR DESCRIPTION
## Summary
- add grid of eight card slots to left pane for future playing card placement
- style card grid with two rows of four spaced rectangles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c51bd4688332bd6c4bc25d336d49