### PR TITLE
Add digestive organ inventories to left pane

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,36 @@
 <body>
     <div id="orientation-warning">Please rotate your device to landscape.</div>
     <div id="game">
-        <div id="left-pane" class="pane">Left Side</div>
+        <div id="left-pane" class="pane">
+            <div class="organ-section">
+                <div class="organ-row">
+                    <div class="organ-label">Stomach</div>
+                    <div id="stomach-inventory" class="inventory-grid">
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                    </div>
+                </div>
+                <div class="arrow">&#8595;</div>
+                <div class="organ-row">
+                    <div class="organ-label">Small Intestine</div>
+                    <div id="small-intestine-inventory" class="inventory-grid">
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                    </div>
+                </div>
+                <div class="arrow">&#8595;</div>
+                <div class="organ-row">
+                    <div class="organ-label">Large Intestine</div>
+                    <div id="large-intestine-inventory" class="inventory-grid">
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                        <div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div><div class="inventory-slot"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
         <div id="divider"></div>
         <div id="right-pane" class="pane">
             <div id="card-grid">

--- a/style.css
+++ b/style.css
@@ -21,6 +21,49 @@ html, body {
     justify-content: center;
 }
 
+#left-pane {
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding-top: 20px;
+}
+
+.organ-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.organ-row {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.organ-label {
+    margin-right: 10px;
+    font-weight: bold;
+}
+
+.inventory-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 40px);
+    grid-template-rows: repeat(3, 40px);
+    gap: 4px;
+}
+
+.inventory-slot {
+    width: 40px;
+    height: 40px;
+    border: 1px solid #333;
+    box-sizing: border-box;
+}
+
+.arrow {
+    font-size: 24px;
+    margin: 10px 0;
+}
+
 #card-grid {
     display: grid;
     grid-template-columns: repeat(4, 100px);


### PR DESCRIPTION
## Summary
- Add stomach, small intestine, and large intestine inventory grids to the left pane with organ labels and connecting arrows.
- Style new inventory grids and arrows with flex and grid layouts for 6x3 slots.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cf990d948332aaf7c45428259771